### PR TITLE
Move flags into templates

### DIFF
--- a/guildenstern/httpresponse.nim
+++ b/guildenstern/httpresponse.nim
@@ -3,9 +3,8 @@ from std/strutils import join
 from std/strformat import fmt
 {.pop.}
 
-const
-  intermediateflags = MSG_NOSIGNAL + MSG_DONTWAIT + MSG_MORE
-  lastflags = MSG_NOSIGNAL + MSG_DONTWAIT
+template intermediateflags(): cint = MSG_NOSIGNAL + MSG_DONTWAIT + MSG_MORE
+template lastflags(): cint = MSG_NOSIGNAL + MSG_DONTWAIT
 
 let
   version = "HTTP/1.1 "


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/83be72dc-3948-4808-a794-34f2dd308df8)

On some POSIX systems `MSG_NOSIGNAL` (And possible other constants) isn't given a variable at compile time so it can't be used in a constant. This replaces the consts with templates so it retains the same semantics but can now compile on systems like ARM.

Unblocks this comment here https://github.com/the-benchmarker/web-frameworks/pull/7653#issuecomment-2254612146

